### PR TITLE
Error Prevention

### DIFF
--- a/pages/AskUserQuestions.py
+++ b/pages/AskUserQuestions.py
@@ -4,6 +4,13 @@
 # After this, the response will be sent to CreateAIReviews.py for the reviews to be generated.
 
 import streamlit as st
+from streamlit_extras.switch_page_button import switch_page
+
+# if any session variables aren't loaded, send user back to the starting page
+if ('userOptions' not in st.session_state or
+        'userInput' not in st.session_state or
+        'storeName' not in st.session_state):
+    switch_page("GreetingPage")
 
 
 def main():

--- a/pages/CreateAIReviews.py
+++ b/pages/CreateAIReviews.py
@@ -7,6 +7,13 @@ import cohere
 from dotenv import load_dotenv
 import streamlit as st
 import clipboard
+from streamlit_extras.switch_page_button import switch_page
+
+# if any session variables aren't loaded, send user back to the starting page
+if ('userOptions' not in st.session_state or
+        'userInput' not in st.session_state or
+        'storeName' not in st.session_state):
+    switch_page("GreetingPage")
 
 load_dotenv()
 COHERE_API_KEY = os.getenv('COHERE_API_KEY')


### PR DESCRIPTION
Currently, when a user refreshes the page on any part of the app that isn't the greeting page, the app crashes. This is because we use st.session_state to save variables across pages, and when we refresh st.session_state is reset alongside all the variables it stored. Then, when we reference these variables, it crashes. To prevent this error, we send the user back to the greeting page if we detect any of these variables are missing